### PR TITLE
Add crude support for BITFIELD and BITFIELD_RO

### DIFF
--- a/command.h
+++ b/command.h
@@ -160,7 +160,9 @@ typedef enum cmd_parse_result {
     ACTION(REQ_REDIS_ZSCAN)                                                    \
     ACTION(REQ_REDIS_EVAL) /* redis requests - eval */                         \
     ACTION(REQ_REDIS_EVALSHA)                                                  \
-    ACTION(REQ_REDIS_PING) /* redis requests - ping/quit */                    \
+    ACTION(REQ_REDIS_BITFIELD)    /* redis requests - binary */                \
+    ACTION(REQ_REDIS_BITFIELD_RO) /* redis requests - binary */                \
+    ACTION(REQ_REDIS_PING)        /* redis requests - ping/quit */             \
     ACTION(REQ_REDIS_QUIT)                                                     \
     ACTION(REQ_REDIS_AUTH)                                                     \
     ACTION(RSP_REDIS_STATUS) /* redis response */                              \


### PR DESCRIPTION
In redis the subcommands assigned to the specified key are applied in one shot. They will always reside in a single slot as they are only applicable to a single key. The user is left with managing the outcome.